### PR TITLE
Mbrailtown/update net framework

### DIFF
--- a/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/App.config
+++ b/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/App.config
@@ -1,25 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/ApplicationInsights.config
+++ b/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/ApplicationInsights.config
@@ -45,7 +45,7 @@
           <IncludedTypes>Event</IncludedTypes>
         </Add>
         <Add Type="ApplicationInsights.Railtown.RailtownTelemetryProcessor, ApplicationInsights.Railtown">
-          <RailtownKey>eyJ1IjoidHN0Mzk3OGRhZGY5YTFlNDliMzgyMjI3NmRmMTU4Nzg2ZTYucmFpbHRvd25sb2dzLmNvbSIsIm8iOiJkNjZhNTQyYS1lYjJkLTRlZmUtOTE5MS00ODhiZWRiM2Q4ZTkiLCJwIjoiNDY5OTJhYzItZWMzNS00MzYxLTgxZDAtNTYzOWRhZjJkN2IzIiwiaCI6Ik5yeTVWWERHaDd4T0tGVytEaDVTNURzeVZpWWVBQW1RUDFKZlg3My9Qbm89IiwiZSI6ImUyMjk1OTdjLThmNGYtNDhkOS1hNDBjLTY0NjkyYWQyZTM2NSJ9</RailtownKey>
+          <RailtownKey>[Copy from one of the configuration sections in Railtown Project settings page for your Environment]</RailtownKey>
         </Add>
       </TelemetryProcessors>
       <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>

--- a/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/ApplicationInsights.config
+++ b/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/ApplicationInsights.config
@@ -45,7 +45,7 @@
           <IncludedTypes>Event</IncludedTypes>
         </Add>
         <Add Type="ApplicationInsights.Railtown.RailtownTelemetryProcessor, ApplicationInsights.Railtown">
-          <RailtownKey>[Copy from one of the configuration sections in Railtown Project settings page for your Environment]</RailtownKey>
+          <RailtownKey>eyJ1IjoidHN0Mzk3OGRhZGY5YTFlNDliMzgyMjI3NmRmMTU4Nzg2ZTYucmFpbHRvd25sb2dzLmNvbSIsIm8iOiJkNjZhNTQyYS1lYjJkLTRlZmUtOTE5MS00ODhiZWRiM2Q4ZTkiLCJwIjoiNDY5OTJhYzItZWMzNS00MzYxLTgxZDAtNTYzOWRhZjJkN2IzIiwiaCI6Ik5yeTVWWERHaDd4T0tGVytEaDVTNURzeVZpWWVBQW1RUDFKZlg3My9Qbm89IiwiZSI6ImUyMjk1OTdjLThmNGYtNDhkOS1hNDBjLTY0NjkyYWQyZTM2NSJ9</RailtownKey>
         </Add>
       </TelemetryProcessors>
       <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>

--- a/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/Railtown.Samples.AppInsights.NetFrameworkSample.csproj
+++ b/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/Railtown.Samples.AppInsights.NetFrameworkSample.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Railtown.Ingest.Sdk.AppInsights.NetFrameworkSample</RootNamespace>
     <AssemblyName>Railtown.Ingest.Sdk.AppInsights.NetFrameworkSample</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/packages.config
+++ b/AppInsights/Railtown.Samples.AppInsights.NetFrameworkSample/packages.config
@@ -1,17 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ApplicationInsights.Railtown" version="2.0.0" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights" version="2.10.0" targetFramework="net461" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-  <package id="Railtown.Ingest.Logs" version="2.0.0" targetFramework="net461" />
-  <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net461" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net461" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.0" targetFramework="net461" />
-  <package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net461" />
-  <package id="System.Text.Json" version="4.7.1" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+
 </packages>

--- a/NLog/Railtown.Samples.NLog.NetFrameworkSample/Railtown.Samples.NLog.NetFrameworkSample.csproj
+++ b/NLog/Railtown.Samples.NLog.NetFrameworkSample/Railtown.Samples.NLog.NetFrameworkSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Serilog/Railtown.Samples.Serilog.NetFrameworkSample/Railtown.Samples.Serilog.NetFrameworkSample.csproj
+++ b/Serilog/Railtown.Samples.Serilog.NetFrameworkSample/Railtown.Samples.Serilog.NetFrameworkSample.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net461</TargetFramework>
+		<TargetFramework>net48</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/log4net/Railtown.Samples.log4net.NetFrameworkSample/Railtown.Samples.log4net.NetFrameworkSample.csproj
+++ b/log4net/Railtown.Samples.log4net.NetFrameworkSample/Railtown.Samples.log4net.NetFrameworkSample.csproj
@@ -4,7 +4,7 @@
 
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
 
   </PropertyGroup>
 


### PR DESCRIPTION
Updated samples project to .net 4.8 to remove dependencies on vulnerable packages
- Newtonsoft.Json 12.0
- System.Text.Encodings.Web 4.7

Demo video showing we received logs from our serilog, nlog, log4net and app insights .net framework samples after the upgrade

https://github.com/RailtownAI/RailtownSamples/assets/86018182/d911c8f1-9bdd-4f57-be55-f847b8a3a3d5

